### PR TITLE
Change multiple calendars to use entity param

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ hide_full_day_events: true
 Multiple Calendars:
 ```yaml
 type: custom:dailygrapher-card
-entities: 
+entity: 
     - calendar.calendar_id
     - calendar.calendar_id_2
 hide_full_day_events: true
@@ -27,8 +27,6 @@ hide_full_day_events: true
 
 ### Options:
 entity: should be a valid and existing calendar entity ID (Tested with google calendar).
-
-entities: should be a list of valid calendar entity IDs.
 
 hide_full_day_events: (boolean) I recommend not showing full day events.
 

--- a/dailygrapher-card.js
+++ b/dailygrapher-card.js
@@ -26,10 +26,7 @@ class DailyGrapherCard extends LitElement {
 
   setConfig(config) {
     if (!config.entity && !config.entities) {
-      throw new Error("You need to define an entity or entities");
-    }
-    if (config.entity && config.entities) {
-      throw new Error("You must only define either entity or entities, not both");
+      throw new Error("You need to define an entity");
     }
     this.config = config;
     this.date = this.getDates();
@@ -59,10 +56,10 @@ class DailyGrapherCard extends LitElement {
     const calendarEntityPromises = [];
     let calendarEntities = [];
 
-    if (this.config.entity) {
-      calendarEntities.push(this.config.entity);
+    if (Array.isArray(this.config.entity)) {
+      calendarEntities = this.config.entity;
     } else {
-      calendarEntities = this.config.entities;
+      calendarEntities.push(this.config.entity);
     }
 
     // retrieve activies in all calendars


### PR DESCRIPTION
This pull request removes the 'entities' parameter and allow setting one or more calendars in then 'entity' param.
I think this makes more sense to do it this way.